### PR TITLE
(fix): Add missing defences 'gripping' and 'deflect' to defTable

### DIFF
--- a/src/base/defs/defTable.js
+++ b/src/base/defs/defTable.js
@@ -203,6 +203,16 @@ export const defTable = {
     serverside: true,
     preempt: true,
   },
+  deflect: {
+    command: "deflect",
+    bals_req: ["balance", "equilibrium"],
+    bals_used: ["free"],
+    blocks: ["death", "prone", "sleeping"],
+    // This is a 2h-spec specific defence, so all the knight/warrior classes get it
+    skills: ["Runewarden", "Paladin", "Infernal", "Unnameable"],
+    serverside: true,
+    preempt: true,
+  },
   density: {
     command: "wear shackle",
     bals_req: ["salve"],
@@ -334,6 +344,15 @@ export const defTable = {
     bals_used: ["equilibrium"],
     skills: ["Serpent"],
     serverside: true,
+  },
+  gripping: {
+    command: "grip",
+    bals_req: ["balance", "equilibrium"],
+    bals_used: ["free"],
+    // Only Shikudo has gripping, Tekura doesn't. Not sure nexSys distinguishes between the two somehow
+    skills: ["Runewarden", "Paladin", "Infernal", "Unnameable", "Monk", "Bard", "Blademaster", "Jester", "Shaman"],
+    serverside: true,
+    preempt: true,
   },
   groundwatch: {
     command: "groundwatch on",


### PR DESCRIPTION
Adding two defences missing as a mini-test for making changes/contributions. May not happen all that often but I like having the option! Hope I got the conventions for defence definitions correct.