### PR TITLE
Add missing Monk defence "splitmind" to defTable

### DIFF
--- a/src/base/defs/defTable.js
+++ b/src/base/defs/defTable.js
@@ -1167,6 +1167,13 @@ export const defTable = {
     blocks: ["death", "anorexia", "sleeping"],
     serverside: true,
   },
+  splitmind: {
+    command: "split mind",
+    bals_req: ["balance", "equilibrium"],
+    bals_used: ["equilibrium"],
+    skills: ["Monk"],
+    serverside: true,
+  },
   skysight: {
     command: "manifest skysight",
     bals_req: ["balance", "equilibrium"],


### PR DESCRIPTION
Did a fresh install of ns3 and realised this was missing. Adding so this def is universally present instead of just in my local edits.